### PR TITLE
Ensure protocol properties are not translated when building sdata que…

### DIFF
--- a/Saleslogix.SData.Client.Test/Linq/SDataExpressionBuilderVisitorTests.cs
+++ b/Saleslogix.SData.Client.Test/Linq/SDataExpressionBuilderVisitorTests.cs
@@ -546,7 +546,8 @@ namespace Saleslogix.SData.Client.Test.Linq
         [Test]
         public void Property_ProtocolProperty_Test()
         {
-            AssertObject((Contact c) => c.Key, "$key");
+            // ensure the protocol properties are kept as literal when building a query
+            AssertObject((Contact c) => c.Key, "Key");
         }
 
         [Test]

--- a/Saleslogix.SData.Client/Content/JsonContentHandler.cs
+++ b/Saleslogix.SData.Client/Content/JsonContentHandler.cs
@@ -70,13 +70,22 @@ namespace Saleslogix.SData.Client.Content
 
         private static SDataResource ReadResource(IDictionary<string, object> obj)
         {
+            HttpStatusCode? httpStatus;
+            try
+            {
+                httpStatus = (HttpStatusCode?) ReadProtocolValue<long?>(obj, "httpStatus");
+            }
+            catch (FormatException)
+            {
+                httpStatus = ReadProtocolValue<HttpStatusCode>(obj, "httpStatus");
+            }
             var resource = new SDataResource
                 {
                     Id = ReadProtocolValue<string>(obj, "id"),
                     Title = ReadProtocolValue<string>(obj, "title"),
                     Updated = ReadProtocolValue<DateTimeOffset?>(obj, "updated"),
                     HttpMethod = ReadProtocolValue<HttpMethod?>(obj, "httpMethod"),
-                    HttpStatus = (HttpStatusCode?) ReadProtocolValue<long?>(obj, "httpStatus"),
+                    HttpStatus = httpStatus,
                     HttpMessage = ReadProtocolValue<string>(obj, "httpMessage"),
                     Location = ReadProtocolValue<string>(obj, "location"),
                     ETag = ReadProtocolValue<string>(obj, "etag"),

--- a/Saleslogix.SData.Client/INamingScheme.cs
+++ b/Saleslogix.SData.Client/INamingScheme.cs
@@ -6,7 +6,7 @@ namespace Saleslogix.SData.Client
 {
     public interface INamingScheme
     {
-        string GetName(MemberInfo member);
+        string GetName(MemberInfo member, bool includeProtocolProps = true);
         string GetName(ParameterInfo param);
     }
 }

--- a/Saleslogix.SData.Client/Linq/SDataExpressionBuilderVisitor.cs
+++ b/Saleslogix.SData.Client/Linq/SDataExpressionBuilderVisitor.cs
@@ -216,7 +216,7 @@ namespace Saleslogix.SData.Client.Linq
                 Append(expression.Expression, ".");
             }
 
-            Append(_namingScheme.GetName(expression.Member));
+            Append(_namingScheme.GetName(expression.Member, false));
             return expression;
         }
 

--- a/Saleslogix.SData.Client/NamingScheme.cs
+++ b/Saleslogix.SData.Client/NamingScheme.cs
@@ -36,19 +36,22 @@ namespace Saleslogix.SData.Client
                 _transform = transform;
             }
 
-            public string GetName(MemberInfo member)
+            public string GetName(MemberInfo member, bool includeProtocolProps = true)
             {
                 Guard.ArgumentNotNull(member, "member");
 
-                var protocolAttr = member.GetCustomAttribute<SDataProtocolPropertyAttribute>();
-                if (protocolAttr != null)
+                if (includeProtocolProps)
                 {
-                    var name = protocolAttr.Value != null ? protocolAttr.Value.ToString() : member.Name;
-                    if (char.IsUpper(name[0]))
+                    var protocolAttr = member.GetCustomAttribute<SDataProtocolPropertyAttribute>();
+                    if (protocolAttr != null)
                     {
-                        name = char.ToLowerInvariant(name[0]) + name.Substring(1);
+                        var name = protocolAttr.Value != null ? protocolAttr.Value.ToString() : member.Name;
+                        if (char.IsUpper(name[0]))
+                        {
+                            name = char.ToLowerInvariant(name[0]) + name.Substring(1);
+                        }
+                        return "$" + name;
                     }
-                    return "$" + name;
                 }
 
 #if !NET_2_0


### PR DESCRIPTION
To address the problem with queries such as:

    client.Query<Contact>.Where(c => c.Account.Id == "SomeAccountId")

which gets translated as 

    where=Account.$key eq 'SomeAccountId'

which fails when parsed by SData:

    could not resolve property: $key of: Sage.SalesLogix.Entities.Account 

I have only implemented the change in the 4.0 project, I can implement in the 3.5 project if needed.