### PR TITLE
Alternate code for reading status code as a string (for SLX 754 Compat)

### DIFF
--- a/Saleslogix.SData.Client/Content/JsonContentHandler.cs
+++ b/Saleslogix.SData.Client/Content/JsonContentHandler.cs
@@ -70,25 +70,34 @@ namespace Saleslogix.SData.Client.Content
 
         private static SDataResource ReadResource(IDictionary<string, object> obj)
         {
+            HttpStatusCode? httpStatus;
+            try
+            {
+                httpStatus = (HttpStatusCode?)ReadProtocolValue<long?>(obj, "httpStatus");
+            }
+            catch (FormatException)
+            {
+                httpStatus = ReadProtocolValue<HttpStatusCode>(obj, "httpStatus");
+            }
             var resource = new SDataResource
-                {
-                    Id = ReadProtocolValue<string>(obj, "id"),
-                    Title = ReadProtocolValue<string>(obj, "title"),
-                    Updated = ReadProtocolValue<DateTimeOffset?>(obj, "updated"),
-                    HttpMethod = ReadProtocolValue<HttpMethod?>(obj, "httpMethod"),
-                    HttpStatus = (HttpStatusCode?) ReadProtocolValue<long?>(obj, "httpStatus"),
-                    HttpMessage = ReadProtocolValue<string>(obj, "httpMessage"),
-                    Location = ReadProtocolValue<string>(obj, "location"),
-                    ETag = ReadProtocolValue<string>(obj, "etag"),
-                    IfMatch = ReadProtocolValue<string>(obj, "ifMatch"),
-                    Url = ReadProtocolValue<Uri>(obj, "url"),
-                    Key = ReadProtocolValue<string>(obj, "key"),
-                    Uuid = ReadProtocolValue<Guid?>(obj, "uuid"),
-                    Lookup = ReadProtocolValue<string>(obj, "lookup"),
-                    Descriptor = ReadProtocolValue<string>(obj, "descriptor"),
-                    Links = ReadLinks(obj),
-                    IsDeleted = ReadProtocolValue<bool?>(obj, "isDeleted")
-                };
+            {
+                Id = ReadProtocolValue<string>(obj, "id"),
+                Title = ReadProtocolValue<string>(obj, "title"),
+                Updated = ReadProtocolValue<DateTimeOffset?>(obj, "updated"),
+                HttpMethod = ReadProtocolValue<HttpMethod?>(obj, "httpMethod"),
+                HttpStatus = httpStatus,
+                HttpMessage = ReadProtocolValue<string>(obj, "httpMessage"),
+                Location = ReadProtocolValue<string>(obj, "location"),
+                ETag = ReadProtocolValue<string>(obj, "etag"),
+                IfMatch = ReadProtocolValue<string>(obj, "ifMatch"),
+                Url = ReadProtocolValue<Uri>(obj, "url"),
+                Key = ReadProtocolValue<string>(obj, "key"),
+                Uuid = ReadProtocolValue<Guid?>(obj, "uuid"),
+                Lookup = ReadProtocolValue<string>(obj, "lookup"),
+                Descriptor = ReadProtocolValue<string>(obj, "descriptor"),
+                Links = ReadLinks(obj),
+                IsDeleted = ReadProtocolValue<bool?>(obj, "isDeleted")
+            };
 
             object value;
             if (obj.TryGetValue("$diagnoses", out value))


### PR DESCRIPTION
SLX 754 sends the HTTP Status code back as a string in the JSON format, however the library currently reads it as a number (inside of JsonContentHandler.ReadResource).  This code addresses the issue by handling the exception and attempting to read the code as an HTTP status string.